### PR TITLE
Add support for Rails 7 and Blacklight 8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test/dummy/db/*.sqlite3
 test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/tmp/
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ class SolrDocument
 
   # ...existing code...
 
-  include Blacklight::Solr::Document::RisFields
-  use_extension(Blacklight::Solr::Document::RisExport)
+  include Blacklight::Ris::DocumentFields
+  use_extension(Blacklight::Ris:DocumentExport)
 
   ris_field_mappings.merge!(
     # Procs are evaluated in context of SolrDocument instance

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Blacklight plugin that adds the ability to download a [RIS representation](https
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'blacklight-ris', '0.1.0'
+gem 'blacklight-ris'
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Blacklight plugin that adds the ability to download a [RIS representation](https
 ### Versioning
 `v0.1.0` -> Known to work with Blacklight v6 and Rails 4
 
+`v0.2.0` -> Known to work with Blacklight v8 and Rails 7 (untested with Blacklight v7 but might work)
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/app/helpers/blacklight_ris_helper.rb
+++ b/app/helpers/blacklight_ris_helper.rb
@@ -4,9 +4,9 @@ module BlacklightRisHelper
   # this helper is called from the Show view and Bookmarks view
   def ris_path(opts = {})
     if controller_name == "bookmarks"
-      bookmarks_path(opts.merge(format: 'ris'))
+      bookmarks_path(format: 'ris')
     else
-      solr_document_path(opts.merge(format: 'ris'))
+      solr_document_path(format: 'ris')
     end
   end
 

--- a/app/models/concerns/blacklight/ris/document_export.rb
+++ b/app/models/concerns/blacklight/ris/document_export.rb
@@ -1,5 +1,5 @@
 
-module Blacklight::Solr::Document::RisExport
+module Blacklight::Ris::DocumentExport
 
   def self.extended(document)
     document.will_export_as(:ris, 'application/x-research-info-systems')

--- a/app/models/concerns/blacklight/ris/document_fields.rb
+++ b/app/models/concerns/blacklight/ris/document_fields.rb
@@ -1,5 +1,5 @@
 
-module Blacklight::Solr::Document::RisFields
+module Blacklight::Ris::DocumentFields
 
   extend ActiveSupport::Concern
 

--- a/app/views/bookmarks/index.ris.erb
+++ b/app/views/bookmarks/index.ris.erb
@@ -1,1 +1,1 @@
-<%= render_ris(@document_list) %>
+<%= render_ris(@response.documents) %>

--- a/blacklight-ris.gemspec
+++ b/blacklight-ris.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails"
-  s.add_dependency "blacklight"
+  s.add_dependency "rails", '>= 7'
+  s.add_dependency "blacklight",  '>= 7'
 
   s.metadata['rubygems_mfa_required'] = 'false'
 end

--- a/blacklight-ris.gemspec
+++ b/blacklight-ris.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "> 4.2"
+  s.add_dependency "rails"
+  s.add_dependency "blacklight"
 
   s.metadata['rubygems_mfa_required'] = 'false'
 end

--- a/config/locales/blacklight_ris.en.yml
+++ b/config/locales/blacklight_ris.en.yml
@@ -1,0 +1,4 @@
+en:
+  blacklight:
+    tools:
+      ris: 'Download in RIS format'

--- a/lib/blacklight/ris.rb
+++ b/lib/blacklight/ris.rb
@@ -1,4 +1,3 @@
-
 require 'blacklight/ris/engine'
 
 module Blacklight

--- a/lib/blacklight/ris/catalog.rb
+++ b/lib/blacklight/ris/catalog.rb
@@ -7,7 +7,7 @@ module Blacklight::Ris
 
     included do
       # this also causes Blacklight's show endpoint to handle .ris
-      add_show_tools_partial(:ris, label: 'Download in RIS format', if: :render_ris_action?, modal: false, path: :ris_path)
+      blacklight_config.add_show_tools_partial(:ris, label: 'Download in RIS format', if: :render_ris_action?, modal: false, path: :ris_path)
     end
 
     private

--- a/lib/blacklight/ris/catalog.rb
+++ b/lib/blacklight/ris/catalog.rb
@@ -7,13 +7,13 @@ module Blacklight::Ris
 
     included do
       # this also causes Blacklight's show endpoint to handle .ris
-      blacklight_config.add_show_tools_partial(:ris, label: 'Download in RIS format', if: :render_ris_action?, modal: false, path: :ris_path)
+      blacklight_config.add_show_tools_partial(:ris, label: I18n.t('blacklight.tools.ris'), if: :render_ris_action?, modal: false, path: :ris_path)
     end
 
     private
 
     def render_ris_action? config, options = {}
-      doc = options[:document] || (options[:document_list] || []).first
+      doc = options[:document] || (@response.documents || []).first
       doc && doc.respond_to?(:export_formats) && doc.export_formats.keys.include?(:ris )
     end
 

--- a/lib/blacklight/ris/engine.rb
+++ b/lib/blacklight/ris/engine.rb
@@ -1,5 +1,5 @@
-module Blacklight
-  module Ris
+
+module Blacklight::Ris
     class Engine < ::Rails::Engine
       isolate_namespace Blacklight::Ris
 
@@ -8,9 +8,9 @@ module Blacklight
       end
 
       initializer 'blacklight-ris.helpers' do |app|
-        ActionView::Base.send :include, BlacklightRisHelper
+        config.after_initialize do
+          ActionView::Base.include BlacklightRisHelper
+        end
       end
-
     end
-  end
 end

--- a/lib/blacklight/ris/version.rb
+++ b/lib/blacklight/ris/version.rb
@@ -1,5 +1,5 @@
 module Blacklight
   module Ris
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Builds off of #1
- Replaced `@document_list` removed in Blacklight 8 with supported `@response.documents` for bookmark export.
- changed the ris url paths to end in `.ris` for better support with citation managers.
- allow RIS format label to be configured via locale